### PR TITLE
Add CLI ejection to footer

### DIFF
--- a/src/ActiveToolLayout.tsx
+++ b/src/ActiveToolLayout.tsx
@@ -37,7 +37,7 @@ export function SidebarContainer() {
       paddingBottom={0}
       borderLeft
       style={{
-        width: '380px',
+        width: '400px',
         overflowY: 'hidden',
         position: 'relative',
       }}

--- a/src/components/SidebarContent.tsx
+++ b/src/components/SidebarContent.tsx
@@ -1,10 +1,12 @@
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Box, Flex, Heading, Text} from '@sanity/ui'
+import {Box, Button, Code, Flex, Heading, Stack, Text} from '@sanity/ui'
 import React, {PropsWithChildren, useCallback, useState} from 'react'
 import {useClient, useProjectId} from 'sanity'
-import {QuickstartCompleted, QuickstartStepCompleted} from '../data/telemetry'
+import {QuickstartCodeCopied, QuickstartCompleted, QuickstartStepCompleted} from '../data/telemetry'
 import {Step} from '../data/types'
 import {StepItem} from './StepItem'
+import {CheckmarkIcon, ClipboardIcon, Icon} from '@sanity/icons'
+import CopyToClipboard from 'react-copy-to-clipboard'
 
 const ACTIVE_STEP = 'walkthrough-plugin:activeStep'
 
@@ -142,10 +144,63 @@ export const SidebarContent: React.FC<
           borderTop: '0.5px solid var(--card-border-color)',
         }}
       >
-        <Text size={1} muted>
-          {footer}
-        </Text>
+        <Flex align={'baseline'} gap={2}>
+          <Text size={1} muted>
+            <Icon symbol={'code-block'} />
+          </Text>
+          <Stack space={4}>
+            <Text size={1} muted>
+              {footer}
+            </Text>
+            <CopyableCodeBlock />
+          </Stack>
+        </Flex>
       </Box>
     </Box>
+  )
+}
+
+function CopyableCodeBlock() {
+  const projectId = useProjectId()
+  const [isCopied, setCopied] = useState(false)
+  const telemetry = useTelemetry()
+  const sanitizedCodeSnippet = `npm create sanity@latest -- --quickstart "h5kquzzf"`.replaceAll(
+    '{{PROJECT_ID}}',
+    `"${projectId}"`,
+  )
+  const onCopy = (text: string) => {
+    setCopied(true)
+    setTimeout(() => setCopied(false), 5000)
+    telemetry.log(QuickstartCodeCopied, {
+      projectId,
+      stepId: 'footer',
+      stepName: 'footer',
+      copiedContent: text,
+    })
+  }
+  return (
+    <CopyToClipboard text={sanitizedCodeSnippet} onCopy={onCopy}>
+      <Flex
+        style={{
+          position: 'relative',
+          boxSizing: 'border-box',
+          cursor: 'pointer',
+        }}
+        align={'baseline'}
+      >
+        <Box style={{overflowX: 'auto'}} paddingY={2}>
+          <Code size={1}>{sanitizedCodeSnippet}</Code>
+        </Box>
+        <Button
+          style={{
+            backgroundColor: 'var(--card-code-bg-color, #f6f6f8)',
+          }}
+          icon={isCopied ? CheckmarkIcon : ClipboardIcon}
+          tone={isCopied ? 'positive' : 'default'}
+          size={0}
+          mode="bleed"
+        />
+      </Flex>
+    </CopyToClipboard>
   )
 }


### PR DESCRIPTION
This PR widens the sidebar for the studio walkthrough plugin and adds a copyable code block to the footer to increase visibility to the eject command.

![SCR-20240501-jhyt](https://github.com/sanity-io/walkthrough-plugin/assets/31733517/a593e401-38f2-4734-9d6c-5fca074e624e)


## Testing
Visit https://test-quickstart-plugin.studio.sanity.work/structure